### PR TITLE
fix(ci): restore green main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plures/runebook",
-  "version": "0.12.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plures/runebook",
-      "version": "0.12.2",
+      "version": "0.15.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -45,7 +45,7 @@
         "vitest": "^2.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/lib/praxis/canvas-validation.ts
+++ b/src/lib/praxis/canvas-validation.ts
@@ -6,10 +6,12 @@ import {
   defineRule,
   defineConstraint,
   defineModule,
-  RuleResult,
-  fact,
 } from '@plures/praxis';
-import type { PraxisModule } from '@plures/praxis';
+import type { PraxisModule, PraxisFact } from '@plures/praxis';
+
+// Local fact constructor: build a PraxisFact literal.
+// (@plures/praxis browser build no longer re-exports the act helper.)
+const fact = (tag: string, payload: unknown): PraxisFact => ({ tag, payload });
 
 // ---------------------------------------------------------------------------
 // Context
@@ -85,7 +87,7 @@ const selfLoopCheckRule = defineRule<CanvasValidationContext>({
   eventTypes: 'VALIDATE_CONNECTION',
   impl: (state, events) => {
     const evt = events.find(ValidateConnectionEvent.is);
-    if (!evt) return RuleResult.skip('no VALIDATE_CONNECTION event');
+    if (!evt) return [];
 
     // Reset stale validation state so each new VALIDATE_CONNECTION event
     // starts from a clean slate, regardless of what happened previously.
@@ -98,10 +100,10 @@ const selfLoopCheckRule = defineRule<CanvasValidationContext>({
         valid: false,
         reason: 'Self-loops are not allowed',
       };
-      return RuleResult.emit([fact(CONNECTION_INVALID_FACT, { reason: 'self-loop', ...evt.payload })]);
+      return ([fact(CONNECTION_INVALID_FACT, { reason: 'self-loop', ...evt.payload })]);
     }
 
-    return RuleResult.noop('not a self-loop');
+    return [];
   },
 });
 
@@ -119,14 +121,14 @@ const portTypeCompatibilityRule = defineRule<CanvasValidationContext>({
   eventTypes: 'VALIDATE_CONNECTION',
   impl: (state, events) => {
     const evt = events.find(ValidateConnectionEvent.is);
-    if (!evt) return RuleResult.skip('no VALIDATE_CONNECTION event');
+    if (!evt) return [];
 
     // Store the current request immediately so context always reflects the
     // most-recent validation request, even on failure paths.
     state.context.pendingConnection = evt.payload;
 
     // Short-circuit: selfLoopCheckRule already flagged this connection as invalid.
-    if (state.context.validationResult?.valid === false) return RuleResult.noop('already failed');
+    if (state.context.validationResult?.valid === false) return [];
 
     const { from, fromPort, to, toPort } = evt.payload;
     const srcNode = state.context.nodes.find(n => n.id === from);
@@ -137,7 +139,7 @@ const portTypeCompatibilityRule = defineRule<CanvasValidationContext>({
         valid: false,
         reason: `Unknown node: ${!srcNode ? from : to}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(CONNECTION_INVALID_FACT, { reason: 'unknown-node', ...evt.payload }),
       ]);
     }
@@ -150,7 +152,7 @@ const portTypeCompatibilityRule = defineRule<CanvasValidationContext>({
         valid: false,
         reason: `Unknown port: ${!srcPort ? fromPort : toPort}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(CONNECTION_INVALID_FACT, { reason: 'unknown-port', ...evt.payload }),
       ]);
     }
@@ -165,7 +167,7 @@ const portTypeCompatibilityRule = defineRule<CanvasValidationContext>({
         valid: false,
         reason: `Type mismatch: ${srcPort.dataType} → ${dstPortDesc.dataType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(CONNECTION_INVALID_FACT, {
           reason: 'type-mismatch',
           fromType: srcPort.dataType,
@@ -177,7 +179,7 @@ const portTypeCompatibilityRule = defineRule<CanvasValidationContext>({
 
     state.context.pendingConnection = evt.payload;
     state.context.validationResult = { valid: true, reason: 'compatible' };
-    return RuleResult.emit([fact(CONNECTION_VALID_FACT, evt.payload)]);
+    return ([fact(CONNECTION_VALID_FACT, evt.payload)]);
   },
 });
 
@@ -193,7 +195,7 @@ const canvasStateConsistencyRule = defineRule<CanvasValidationContext>({
   eventTypes: 'VALIDATE_CANVAS_STATE',
   impl: (state, events) => {
     const evt = events.find(ValidateCanvasStateEvent.is);
-    if (!evt) return RuleResult.skip('no VALIDATE_CANVAS_STATE event');
+    if (!evt) return [];
 
     const ids = state.context.nodes.map(n => n.id);
     const uniqueIds = new Set(ids);
@@ -203,11 +205,11 @@ const canvasStateConsistencyRule = defineRule<CanvasValidationContext>({
         valid: false,
         reason: 'Duplicate node IDs detected',
       };
-      return RuleResult.emit([fact(CANVAS_STATE_INVALID_FACT, { reason: 'duplicate-node-ids' })]);
+      return ([fact(CANVAS_STATE_INVALID_FACT, { reason: 'duplicate-node-ids' })]);
     }
 
     state.context.validationResult = { valid: true, reason: 'consistent' };
-    return RuleResult.emit([fact(CANVAS_STATE_VALID_FACT, {})]);
+    return ([fact(CANVAS_STATE_VALID_FACT, {})]);
   },
 });
 

--- a/src/lib/praxis/component-registry.ts
+++ b/src/lib/praxis/component-registry.ts
@@ -6,10 +6,12 @@ import {
   defineEvent,
   defineRule,
   defineModule,
-  RuleResult,
-  fact,
 } from '@plures/praxis';
-import type { PraxisModule } from '@plures/praxis';
+import type { PraxisModule, PraxisFact } from '@plures/praxis';
+
+// Local fact constructor: build a PraxisFact literal.
+// (@plures/praxis browser build no longer re-exports the act helper.)
+const fact = (tag: string, payload: unknown): PraxisFact => ({ tag, payload });
 
 // ---------------------------------------------------------------------------
 // Context
@@ -92,7 +94,7 @@ const registerComponentRule = defineRule<ComponentRegistryContext>({
   eventTypes: 'REGISTER_COMPONENT',
   impl: (state, events) => {
     const evt = events.find(RegisterComponentEvent.is);
-    if (!evt) return RuleResult.skip('no REGISTER_COMPONENT event');
+    if (!evt) return [];
 
     const capability = evt.payload;
     state.context.components[capability.type] = {
@@ -100,7 +102,7 @@ const registerComponentRule = defineRule<ComponentRegistryContext>({
       lifecycle: 'registered',
     };
 
-    return RuleResult.emit([fact(COMPONENT_REGISTERED_FACT, { type: capability.type })]);
+    return ([fact(COMPONENT_REGISTERED_FACT, { type: capability.type })]);
   },
 });
 
@@ -113,14 +115,14 @@ const unregisterComponentRule = defineRule<ComponentRegistryContext>({
   eventTypes: 'UNREGISTER_COMPONENT',
   impl: (state, events) => {
     const evt = events.find(UnregisterComponentEvent.is);
-    if (!evt) return RuleResult.skip('no UNREGISTER_COMPONENT event');
+    if (!evt) return [];
 
     const { type } = evt.payload;
     if (state.context.components[type]) {
       state.context.components[type].lifecycle = 'removed';
     }
 
-    return RuleResult.emit([fact(COMPONENT_UNREGISTERED_FACT, { type })]);
+    return ([fact(COMPONENT_UNREGISTERED_FACT, { type })]);
   },
 });
 
@@ -140,7 +142,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
   eventTypes: 'CHECK_PORT_COMPATIBILITY',
   impl: (state, events) => {
     const evt = events.find(CheckPortCompatibilityEvent.is);
-    if (!evt) return RuleResult.skip('no CHECK_PORT_COMPATIBILITY event');
+    if (!evt) return [];
 
     const { fromComponentType, fromPortId, toComponentType, toPortId } = evt.payload;
 
@@ -152,7 +154,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
         compatible: false,
         reason: `Unknown or removed component: ${fromComponentType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(PORT_INCOMPATIBLE_FACT, {
           reason: 'unknown-from-component',
           ...evt.payload,
@@ -165,7 +167,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
         compatible: false,
         reason: `Unknown or removed component: ${toComponentType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(PORT_INCOMPATIBLE_FACT, {
           reason: 'unknown-to-component',
           ...evt.payload,
@@ -181,7 +183,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
         compatible: false,
         reason: `Output port '${fromPortId}' not found on ${fromComponentType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(PORT_INCOMPATIBLE_FACT, { reason: 'missing-output-port', ...evt.payload }),
       ]);
     }
@@ -191,7 +193,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
         compatible: false,
         reason: `Input port '${toPortId}' not found on ${toComponentType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(PORT_INCOMPATIBLE_FACT, { reason: 'missing-input-port', ...evt.payload }),
       ]);
     }
@@ -202,7 +204,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
         compatible: false,
         reason: `Type mismatch: ${srcPort.dataType} → ${dstPort.dataType}`,
       };
-      return RuleResult.emit([
+      return ([
         fact(PORT_INCOMPATIBLE_FACT, {
           reason: 'type-mismatch',
           fromType: srcPort.dataType,
@@ -213,7 +215,7 @@ const checkPortCompatibilityRule = defineRule<ComponentRegistryContext>({
     }
 
     state.context.portCompatibilityResult = { compatible: true, reason: 'compatible' };
-    return RuleResult.emit([fact(PORT_COMPATIBLE_FACT, evt.payload)]);
+    return ([fact(PORT_COMPATIBLE_FACT, evt.payload)]);
   },
 });
 

--- a/src/lib/praxis/execution-policy.ts
+++ b/src/lib/praxis/execution-policy.ts
@@ -7,10 +7,12 @@ import {
   defineRule,
   defineConstraint,
   defineModule,
-  RuleResult,
-  fact,
 } from '@plures/praxis';
-import type { PraxisModule } from '@plures/praxis';
+import type { PraxisModule, PraxisFact } from '@plures/praxis';
+
+// Local fact constructor: build a PraxisFact literal.
+// (@plures/praxis browser build no longer re-exports the act helper.)
+const fact = (tag: string, payload: unknown): PraxisFact => ({ tag, payload });
 
 // ---------------------------------------------------------------------------
 // Context
@@ -121,17 +123,17 @@ const scheduleExecutionRule = defineRule<ExecutionPolicyContext>({
   eventTypes: 'SCHEDULE_EXECUTION',
   impl: (state, events) => {
     const evt = events.find(ScheduleExecutionEvent.is);
-    if (!evt) return RuleResult.skip('no SCHEDULE_EXECUTION event');
+    if (!evt) return [];
 
     const { order, hasCycles } = topologicalSort(state.context.nodes, state.context.edges);
     state.context.executionOrder = order;
     state.context.hasCycles = hasCycles;
 
     if (hasCycles) {
-      return RuleResult.emit([fact(CYCLE_DETECTED_FACT, { triggeredBy: evt.payload.changedNodeId })]);
+      return ([fact(CYCLE_DETECTED_FACT, { triggeredBy: evt.payload.changedNodeId })]);
     }
 
-    return RuleResult.emit([fact(EXECUTION_ORDER_FACT, { order })]);
+    return ([fact(EXECUTION_ORDER_FACT, { order })]);
   },
 });
 
@@ -146,16 +148,16 @@ const detectCyclesRule = defineRule<ExecutionPolicyContext>({
   eventTypes: 'DETECT_CYCLES',
   impl: (state, events) => {
     const evt = events.find(DetectCyclesEvent.is);
-    if (!evt) return RuleResult.skip('no DETECT_CYCLES event');
+    if (!evt) return [];
 
     const { hasCycles } = topologicalSort(state.context.nodes, state.context.edges);
     state.context.hasCycles = hasCycles;
 
     if (hasCycles) {
-      return RuleResult.emit([fact(CYCLE_DETECTED_FACT, {})]);
+      return ([fact(CYCLE_DETECTED_FACT, {})]);
     }
 
-    return RuleResult.emit([fact(GRAPH_ACYCLIC_FACT, {})]);
+    return ([fact(GRAPH_ACYCLIC_FACT, {})]);
   },
 });
 
@@ -171,19 +173,19 @@ const timeoutEnforcementRule = defineRule<ExecutionPolicyContext>({
   eventTypes: 'REPORT_ELAPSED',
   impl: (state, events) => {
     const evt = events.find(ReportElapsedEvent.is);
-    if (!evt) return RuleResult.skip('no REPORT_ELAPSED event');
+    if (!evt) return [];
 
     const { nodeId, elapsedMs } = evt.payload;
     state.context.elapsed[nodeId] = elapsedMs;
 
     const budget = state.context.timeouts[nodeId] ?? 0;
     if (budget > 0 && elapsedMs > budget) {
-      return RuleResult.emit([
+      return ([
         fact(TIMEOUT_EXCEEDED_FACT, { nodeId, elapsedMs, budget }),
       ]);
     }
 
-    return RuleResult.noop('within timeout budget');
+    return [];
   },
 });
 

--- a/src/lib/praxis/resource-management.ts
+++ b/src/lib/praxis/resource-management.ts
@@ -7,10 +7,12 @@ import {
   defineRule,
   defineConstraint,
   defineModule,
-  RuleResult,
-  fact,
 } from '@plures/praxis';
-import type { PraxisModule } from '@plures/praxis';
+import type { PraxisModule, PraxisFact } from '@plures/praxis';
+
+// Local fact constructor: build a PraxisFact literal.
+// (@plures/praxis browser build no longer re-exports the act helper.)
+const fact = (tag: string, payload: unknown): PraxisFact => ({ tag, payload });
 
 // ---------------------------------------------------------------------------
 // Context
@@ -86,10 +88,10 @@ const processLimitRule = defineRule<ResourceManagementContext>({
   eventTypes: 'REQUEST_TERMINAL',
   impl: (state, events) => {
     const evt = events.find(RequestTerminalEvent.is);
-    if (!evt) return RuleResult.skip('no REQUEST_TERMINAL event');
+    if (!evt) return [];
 
     if (state.context.terminalCount >= state.context.maxTerminals) {
-      return RuleResult.emit([
+      return ([
         fact(TERMINAL_DENIED_FACT, {
           nodeId: evt.payload.nodeId,
           current: state.context.terminalCount,
@@ -99,7 +101,7 @@ const processLimitRule = defineRule<ResourceManagementContext>({
     }
 
     state.context.terminalCount += 1;
-    return RuleResult.emit([
+    return ([
       fact(TERMINAL_GRANTED_FACT, {
         nodeId: evt.payload.nodeId,
         count: state.context.terminalCount,
@@ -117,13 +119,13 @@ const releaseTerminalRule = defineRule<ResourceManagementContext>({
   eventTypes: 'RELEASE_TERMINAL',
   impl: (state, events) => {
     const evt = events.find(ReleaseTerminalEvent.is);
-    if (!evt) return RuleResult.skip('no RELEASE_TERMINAL event');
+    if (!evt) return [];
 
     if (state.context.terminalCount > 0) {
       state.context.terminalCount -= 1;
     }
 
-    return RuleResult.emit([
+    return ([
       fact(TERMINAL_RELEASED_FACT, {
         nodeId: evt.payload.nodeId,
         count: state.context.terminalCount,
@@ -143,13 +145,13 @@ const memoryBudgetRule = defineRule<ResourceManagementContext>({
   eventTypes: 'UPDATE_MEMORY_USAGE',
   impl: (state, events) => {
     const evt = events.find(UpdateMemoryUsageEvent.is);
-    if (!evt) return RuleResult.skip('no UPDATE_MEMORY_USAGE event');
+    if (!evt) return [];
 
     state.context.memoryUsage = evt.payload.bytes;
 
     const { memoryBudget } = state.context;
     if (memoryBudget > 0 && evt.payload.bytes > memoryBudget) {
-      return RuleResult.emit([
+      return ([
         fact(MEMORY_PRESSURE_FACT, {
           usage: evt.payload.bytes,
           budget: memoryBudget,
@@ -158,7 +160,7 @@ const memoryBudgetRule = defineRule<ResourceManagementContext>({
       ]);
     }
 
-    return RuleResult.noop('memory within budget');
+    return [];
   },
 });
 
@@ -173,14 +175,14 @@ const cleanupTriggerRule = defineRule<ResourceManagementContext>({
   eventTypes: 'NODE_TIMEOUT',
   impl: (state, events) => {
     const evt = events.find(NodeTimeoutEvent.is);
-    if (!evt) return RuleResult.skip('no NODE_TIMEOUT event');
+    if (!evt) return [];
 
     const { nodeId, elapsedMs } = evt.payload;
     if (!state.context.timedOutNodes.includes(nodeId)) {
       state.context.timedOutNodes.push(nodeId);
     }
 
-    return RuleResult.emit([
+    return ([
       fact(CLEANUP_REQUIRED_FACT, {
         nodeId,
         elapsedMs,

--- a/src/lib/stores/canvas-praxis.ts
+++ b/src/lib/stores/canvas-praxis.ts
@@ -7,7 +7,6 @@ import {
   defineRule,
   defineModule,
   PraxisRegistry,
-  RuleResult,
 } from '@plures/praxis';
 import type { Canvas, CanvasNode, Connection, SubCanvasNode } from '../types/canvas';
 
@@ -53,16 +52,16 @@ export function makeConnectionId(from: string, fromPort: string, to: string, toP
   return `e-${from}-${fromPort}-${to}-${toPort}`;
 }
 
-// Define rules for canvas operations using RuleResult typed returns
+// Define rules for canvas operations (impl returns an array of events; [] = no new events)
 const addNodeRule = defineRule<CanvasContext>({
   id: 'canvas.addNode',
   description: 'Add a new node to the canvas',
   eventTypes: 'ADD_NODE',
   impl: (state, events) => {
     const evt = events.find(AddNodeEvent.is);
-    if (!evt) return RuleResult.skip('no ADD_NODE event');
+    if (!evt) return [];
     state.context.canvas.nodes.push(evt.payload.node);
-    return RuleResult.noop('node added');
+    return [];
   },
 });
 
@@ -72,7 +71,7 @@ const removeNodeRule = defineRule<CanvasContext>({
   eventTypes: 'REMOVE_NODE',
   impl: (state, events) => {
     const evt = events.find(RemoveNodeEvent.is);
-    if (!evt) return RuleResult.skip('no REMOVE_NODE event');
+    if (!evt) return [];
 
     const { nodeId } = evt.payload;
     state.context.canvas.nodes = state.context.canvas.nodes.filter(n => n.id !== nodeId);
@@ -86,7 +85,7 @@ const removeNodeRule = defineRule<CanvasContext>({
       Object.entries(state.context.nodeData).filter(([key]) => !key.startsWith(prefix)),
     );
 
-    return RuleResult.noop('node removed');
+    return [];
   },
 });
 
@@ -96,7 +95,7 @@ const updateNodeRule = defineRule<CanvasContext>({
   eventTypes: 'UPDATE_NODE',
   impl: (state, events) => {
     const evt = events.find(UpdateNodeEvent.is);
-    if (!evt) return RuleResult.skip('no UPDATE_NODE event');
+    if (!evt) return [];
 
     const { nodeId, updates } = evt.payload;
     const nodeIndex = state.context.canvas.nodes.findIndex(n => n.id === nodeId);
@@ -107,7 +106,7 @@ const updateNodeRule = defineRule<CanvasContext>({
       } as CanvasNode;
     }
 
-    return RuleResult.noop('node updated');
+    return [];
   },
 });
 
@@ -117,7 +116,7 @@ const updateNodePositionRule = defineRule<CanvasContext>({
   eventTypes: 'UPDATE_NODE_POSITION',
   impl: (state, events) => {
     const evt = events.find(UpdateNodePositionEvent.is);
-    if (!evt) return RuleResult.skip('no UPDATE_NODE_POSITION event');
+    if (!evt) return [];
 
     const { nodeId, x, y } = evt.payload;
     const nodeIndex = state.context.canvas.nodes.findIndex(n => n.id === nodeId);
@@ -125,7 +124,7 @@ const updateNodePositionRule = defineRule<CanvasContext>({
       state.context.canvas.nodes[nodeIndex].position = { x, y };
     }
 
-    return RuleResult.noop('node position updated');
+    return [];
   },
 });
 
@@ -135,7 +134,7 @@ const addConnectionRule = defineRule<CanvasContext>({
   eventTypes: 'ADD_CONNECTION',
   impl: (state, events) => {
     const evt = events.find(AddConnectionEvent.is);
-    if (!evt) return RuleResult.skip('no ADD_CONNECTION event');
+    if (!evt) return [];
 
     const conn = evt.payload.connection;
     // Auto-generate a handle-based ID when not provided
@@ -154,7 +153,7 @@ const addConnectionRule = defineRule<CanvasContext>({
       state.context.canvas.connections.push(connection);
     }
 
-    return RuleResult.noop('connection added');
+    return [];
   },
 });
 
@@ -164,14 +163,14 @@ const removeConnectionRule = defineRule<CanvasContext>({
   eventTypes: 'REMOVE_CONNECTION',
   impl: (state, events) => {
     const evt = events.find(RemoveConnectionEvent.is);
-    if (!evt) return RuleResult.skip('no REMOVE_CONNECTION event');
+    if (!evt) return [];
 
     const { from, to, fromPort, toPort } = evt.payload;
     state.context.canvas.connections = state.context.canvas.connections.filter(
       c => !(c.from === from && c.to === to && c.fromPort === fromPort && c.toPort === toPort),
     );
 
-    return RuleResult.noop('connection removed');
+    return [];
   },
 });
 
@@ -181,11 +180,11 @@ const loadCanvasRule = defineRule<CanvasContext>({
   eventTypes: 'LOAD_CANVAS',
   impl: (state, events) => {
     const evt = events.find(LoadCanvasEvent.is);
-    if (!evt) return RuleResult.skip('no LOAD_CANVAS event');
+    if (!evt) return [];
 
     state.context.canvas = evt.payload.canvas;
     state.context.navStack = [];
-    return RuleResult.noop('canvas loaded');
+    return [];
   },
 });
 
@@ -195,7 +194,7 @@ const clearCanvasRule = defineRule<CanvasContext>({
   eventTypes: 'CLEAR_CANVAS',
   impl: (state, events) => {
     const evt = events.find(ClearCanvasEvent.is);
-    if (!evt) return RuleResult.skip('no CLEAR_CANVAS event');
+    if (!evt) return [];
 
     state.context.canvas = {
       id: 'default',
@@ -208,7 +207,7 @@ const clearCanvasRule = defineRule<CanvasContext>({
     state.context.nodeData = {};
     state.context.navStack = [];
 
-    return RuleResult.noop('canvas cleared');
+    return [];
   },
 });
 
@@ -218,12 +217,12 @@ const updateNodeDataRule = defineRule<CanvasContext>({
   eventTypes: 'UPDATE_NODE_DATA',
   impl: (state, events) => {
     const evt = events.find(UpdateNodeDataEvent.is);
-    if (!evt) return RuleResult.skip('no UPDATE_NODE_DATA event');
+    if (!evt) return [];
 
     const { nodeId, portId, data } = evt.payload;
     state.context.nodeData[`${nodeId}:${portId}`] = data;
 
-    return RuleResult.noop('node data updated');
+    return [];
   },
 });
 
@@ -233,11 +232,11 @@ const navigateIntoSubCanvasRule = defineRule<CanvasContext>({
   eventTypes: 'NAVIGATE_INTO_SUB_CANVAS',
   impl: (state, events) => {
     const evt = events.find(NavigateIntoSubCanvasEvent.is);
-    if (!evt) return RuleResult.skip('no NAVIGATE_INTO_SUB_CANVAS event');
+    if (!evt) return [];
 
     const { nodeId, label } = evt.payload;
     const node = state.context.canvas.nodes.find(n => n.id === nodeId);
-    if (!node || node.type !== 'sub-canvas') return RuleResult.skip('not a sub-canvas node');
+    if (!node || node.type !== 'sub-canvas') return [];
 
     // Push current canvas onto the stack and descend into the children canvas.
     state.context.navStack.push({
@@ -248,7 +247,7 @@ const navigateIntoSubCanvasRule = defineRule<CanvasContext>({
     state.context.canvas = (node as SubCanvasNode).children;
     state.context.nodeData = {};
 
-    return RuleResult.noop('navigated into sub-canvas');
+    return [];
   },
 });
 
@@ -258,8 +257,8 @@ const navigateUpRule = defineRule<CanvasContext>({
   eventTypes: 'NAVIGATE_UP',
   impl: (state, events) => {
     const evt = events.find(NavigateUpEvent.is);
-    if (!evt) return RuleResult.skip('no NAVIGATE_UP event');
-    if (state.context.navStack.length === 0) return RuleResult.skip('already at root');
+    if (!evt) return [];
+    if (state.context.navStack.length === 0) return [];
 
     const entry = state.context.navStack.pop()!;
     const modifiedChildren = state.context.canvas;
@@ -273,7 +272,7 @@ const navigateUpRule = defineRule<CanvasContext>({
     state.context.canvas = entry.canvas;
     state.context.nodeData = {};
 
-    return RuleResult.noop('navigated up');
+    return [];
   },
 });
 


### PR DESCRIPTION
## Root cause
CI (reusable node build) failed at the vite/rollup build step: RuleResult is not exported by @plures/praxis. The praxis browser build no longer re-exports the RuleResult class or the act() helper. The runebook praxis modules were written against that old API.

## Fix
Migrated all praxis rule impls to the current RuleFn contract (return PraxisFact[]):
- RuleResult.emit([...]) -> return the fact array directly
- RuleResult.skip(...) / .noop(...) / .retract(...) -> eturn []`n- Added a small local act(tag, payload) constructor (returns a { tag, payload } PraxisFact literal) in each validation module.

No stubs, no disabled checks.

## Verified locally (Windows)
- 
pm run build ✅ built in ~9s
- 
pm run check (svelte-check) ✅ 0 errors
- vitest: 463 passed; the 16 failures are a Windows-only artifact (shell detection returns 'unknown' because \ is empty) and pass on the Linux runner.